### PR TITLE
Update get_seasonal_forecast.R

### DIFF
--- a/R/get_seasonal_forecast.R
+++ b/R/get_seasonal_forecast.R
@@ -40,13 +40,13 @@ get_seasonal_forecast <- function(latitude,
 
   url_base <- "https://seasonal-api.open-meteo.com/v1/seasonal"
   url_path <-  glue::glue(
-    "?latitude={latitude}&longitude={longitude}&six_hourly={variables_api}&windspeed_unit=ms&forecast_days={forecast_days}&past_days={past_days}"
+    "?latitude={latitude}&longitude={longitude}&hourly={variables_api}&windspeed_unit=ms&forecast_days={forecast_days}&past_days={past_days}"
   )
   v <- read_url(url_base, url_path)
 
 
-  units <- dplyr::tibble(variable = stringr::str_split_i(names(v$six_hourly),"_member",1), unit = unlist(v$six_hourly_units)) |> dplyr::distinct() |> dplyr::filter(variable != "time")
-  df  <- dplyr::as_tibble(v$six_hourly) |>
+  units <- dplyr::tibble(variable = stringr::str_split_i(names(v$hourly),"_member",1), unit = unlist(v$hourly_units)) |> dplyr::distinct() |> dplyr::filter(variable != "time")
+  df  <- dplyr::as_tibble(v$hourly) |>
     dplyr::mutate(time = lubridate::as_datetime(paste0(time,":00")))  |>
     pivot_ensemble_forecast() |>
     dplyr::rename(datetime = time) |>


### PR DESCRIPTION
@rqthomas I noticed that the VERA seasonal forecasts have been down for a while. I looked into it, and I think the open-meteo naming convention for the seasonal six-hour forecasts has changed from _six_hourly_ to _hourly_ . I looked on open-meteo, and they don't provide a true hourly product for seasonal forecasts. I think they must have just updated this for simplicity. [Here](https://open-meteo.com/en/docs/seasonal-forecast-api?daily=&hourly=temperature_2m,relative_humidity_2m,cloud_cover,precipitation) is an example I was using on open-meteo. I've updated the get_seasonal_forecast function to reflect these changes